### PR TITLE
Ensure JSON content type

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -36,7 +36,7 @@ export const AuthContextProvider = ({ children }: AuthContextProviderProps) => {
     const userAndTokenUpdate = async (userData: UserDTO, userToken: string, companyToken: string, basicAuthHeader: string) => {
         api.defaults.headers.common['Authorization'] = basicAuthHeader;
         api.defaults.headers.common['token'] = companyToken;
-        delete api.defaults.headers.common['Content-Type'];
+        api.defaults.headers.common['Content-Type'] = 'application/json';
       
         setUser(userData);
     }


### PR DESCRIPTION
## Summary
- set default `Content-Type` header after authentication

## Testing
- `npm test` *(fails: Missing script)*
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6849c13cdfc4832896f1ef1213bb4f4d