### PR TITLE
Limit upload file name length

### DIFF
--- a/src/screens/Upload.tsx
+++ b/src/screens/Upload.tsx
@@ -136,6 +136,17 @@ export const Upload = () => {
     return Buffer.from(bytes).toString("base64");
   };
 
+  const truncateFileName = (name: string, max = 30) => {
+    if (name.length <= max) return name;
+    const extIndex = name.lastIndexOf(".");
+    if (extIndex === -1) {
+      return name.slice(0, max);
+    }
+    const ext = name.slice(extIndex);
+    const allowedBase = max - ext.length;
+    return name.slice(0, allowedBase) + ext;
+  };
+
 const enviarArquivo = async () => {
   try {
     console.log("⏳ Iniciando envio do arquivo...");
@@ -203,6 +214,21 @@ const enviarArquivo = async () => {
         console.error("❌ Erro ao ler o arquivo:", err);
         throw err;
       }
+    }
+
+    const truncated = truncateFileName(fileName);
+    if (truncated !== fileName) {
+      toast.show({
+        placement: "top",
+        render: ({ id }) => (
+          <ToastMessage
+            id={id}
+            title="Nome do arquivo truncado para 30 caracteres"
+            onClose={() => toast.close(id)}
+          />
+        ),
+      });
+      fileName = truncated;
     }
 
     const payload = {
@@ -509,6 +535,7 @@ const enviarArquivo = async () => {
                                 ? "numeric"
                                 : "default"
                             }
+                            maxLength={30}
                             value={valoresIndices[indice.codigo] || ""}
                             onChangeText={(text) =>
                               setValoresIndices((prev) => ({


### PR DESCRIPTION
## Summary
- truncate upload filenames to 30 chars
- notify the user when truncation occurs
- enforce server-side length with maxLength on indice input

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ad2c44ec48328b0532b93fb67e9a1