### PR TITLE
Limit indice values length

### DIFF
--- a/src/screens/Upload.tsx
+++ b/src/screens/Upload.tsx
@@ -237,13 +237,31 @@ const enviarArquivo = async () => {
       tipoDocumentoVO: {
         codigo: tipoDocumentoSelecionado.codigo,
       },
-      indiceArquivoVOs: tipoDocumentoSelecionado.listaIndice.map((indice) => ({
-        codigo: indice.codigo,
-        nomeIndice: indice.nome,
-        tipoIndice: indice.tipoIndice,
-        descricao: indice.descricao || indice.nome,
-        valor: valoresIndices[indice.codigo],
-      })),
+      indiceArquivoVOs: tipoDocumentoSelecionado.listaIndice.map((indice) => {
+        const original = valoresIndices[indice.codigo];
+        const valor = original?.slice(0, 30);
+
+        if (original && original.length > 30) {
+          toast.show({
+            placement: "top",
+            render: ({ id }) => (
+              <ToastMessage
+                id={id}
+                title={`Valor do índice ${indice.nome} truncado para 30 caracteres`}
+                onClose={() => toast.close(id)}
+              />
+            ),
+          });
+        }
+
+        return {
+          codigo: indice.codigo,
+          nomeIndice: indice.nome,
+          tipoIndice: indice.tipoIndice,
+          descricao: indice.descricao || indice.nome,
+          valor,
+        };
+      }),
       file_base64: fileBase64,
     };
 


### PR DESCRIPTION
## Summary
- slice each indice value in the upload payload to 30 characters
- notify when indice values are truncated

## Testing
- `npm test` *(fails: Missing script)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684ae2dd822c8328961afe23f7a5b4c2